### PR TITLE
Decrease tilt of credit roll text

### DIFF
--- a/styles/opening_crawl.css
+++ b/styles/opening_crawl.css
@@ -153,7 +153,7 @@
 	text-align: justify;
 	word-wrap: break-word;
 	transform-origin: 50% 100%;
-	transform: perspective(300px) rotateX(25deg);
+	transform: perspective(300px) rotateX(20deg);
 }
 
 .ffg-star-wars-enhancements-opening-crawl .titles > div {


### PR DESCRIPTION
The original styling expects a fixed window size, which our view port doesn't have. This causes the text to 25deg tilt to seem too exaggerated.