### PR TITLE
Change combatant name and icon in preCreate hook.

### DIFF
--- a/ffg-star-wars-enhancements.js
+++ b/ffg-star-wars-enhancements.js
@@ -6,7 +6,7 @@ import {
     attack_animation
 } from './scripts/animation.js'
 import { init as opening_crawl_init, ready as opening_crawl_ready } from './scripts/opening_crawl.js'
-import { init as rename_init, rename_actors } from './scripts/rename.js'
+import { init as rename_init, rename_combatant } from './scripts/rename.js'
 import {
     init as dice_helper_init,
     dice_helper,
@@ -114,9 +114,11 @@ Hooks.on("getSceneControlButtons", (controls) => {
 });
 
 Hooks.on("createCombatant", (combatant) => {
-    rename_actors(combatant);
     strain_reminder(combatant);
 })
+Hooks.on("preCreateCombatant", combatant => {
+    rename_combatant(combatant);
+});
 
 function register_hooks() {
     libWrapper.register(


### PR DESCRIPTION
This fixes an issue where reloading sometimes leads to combatants resetting to
their original image and name.

Updating embedded documents directly can lead to a race condition where
the update is sent to all connected clients, but not saved in the DB.
This leads to some icons and names reverting when reloading foundry. By
utilizing the preUpdate hook, the data of the Combatant can be edited
before sending the create request to the db, thus ensuring the changed
icon and name are stored in the db. The hook only runs on the client
that initiates the create request, eliminating the need to check that a
GM is running it, and preventing it from running multiple times if an
additional GM is logged in.

Additionally, this now handles Combatants created from an actor instead
of a token, making usage with the canvas disabled possible.

Discord contact Bolts#9418