### PR TITLE
fix(opening-crawl): fix premature fade of text during opening crawl

### DIFF
--- a/scripts/opening_crawl.js
+++ b/scripts/opening_crawl.js
@@ -77,7 +77,7 @@ export function init() {
         scope: "world",
         config: false,
         type: Number,
-        default: 850,
+        default: 350,
     });
     log('opening-crawl', 'Initialized');
 }

--- a/styles/opening_crawl.css
+++ b/styles/opening_crawl.css
@@ -153,7 +153,7 @@
 	text-align: justify;
 	word-wrap: break-word;
 	transform-origin: 50% 100%;
-	transform: perspective(300px) rotateX(20deg);
+	transform: perspective(300px) rotateX(25deg);
 }
 
 .ffg-star-wars-enhancements-opening-crawl .titles > div {

--- a/styles/opening_crawl.css
+++ b/styles/opening_crawl.css
@@ -69,7 +69,7 @@
 	overflow: hidden;
 	letter-spacing: 0.15em;
 	font-weight: 700;
-	font-size: 1em;
+	font-size: 16px;
     font-family: 'News Cycle';
 	line-height: normal;
 	font-variant-ligatures: none;
@@ -364,7 +364,7 @@
 	}
 
 	100% {
-		top: 20%;
+		top: -18.1524%;
 		opacity: 0;
 	}
 }
@@ -380,7 +380,7 @@
 	}
 
 	100% {
-		top: 20%;
+		top: -18.1524%;
 		opacity: 0;
 	}
 }
@@ -396,7 +396,7 @@
 	}
 
 	100% {
-		top: 20%;
+		top: -18.1524%;
 		opacity: 0;
 	}
 }
@@ -689,7 +689,7 @@
 	}
 
 	100% {
-		top: 20%;
+		top: -18.1524%;
 		opacity: 0;
 	}
 }
@@ -705,7 +705,7 @@
 	}
 
 	100% {
-		top: 20%;
+		top: -18.1524%;
 		opacity: 0;
 	}
 }
@@ -721,7 +721,7 @@
 	}
 
 	100% {
-		top: 20%;
+		top: -18.1524%;
 		opacity: 0;
 	}
 }
@@ -737,7 +737,7 @@
 	}
 
 	100% {
-		top: 20%;
+		top: -18.1524%;
 		opacity: 0;
 	}
 }


### PR DESCRIPTION
This change does three things:
- Reverts an unsuccessful attempt to fix this bug
- Resets the default font size to what it should have originally been
- Sets the parent font-size to be consistent with the original source and corrects the actual bug, ensuring the text reaches the top before beginning to fade out

Fixes #71 