### PR TITLE
fix(animation): fix animation settings when viewed under lower resolutions

### DIFF
--- a/scripts/animation.js
+++ b/scripts/animation.js
@@ -417,7 +417,9 @@ class attack_animation_UISettings extends FormApplication {
             system: {title: game.system.data.title, menus: [], settings: []},
         };
 
-        // Classify all settings
+        // Classify all settings, separating animations and sounds into a list of implied pairs.
+        let enableSetting;
+        let settingPairs = [];
         // noinspection JSUnusedLocalSymbols
         for (let setting of gs.settings.values()) {
             // Exclude settings the user cannot change
@@ -436,8 +438,17 @@ class attack_animation_UISettings extends FormApplication {
 
             // Classify setting
             const name = s.module;
-            if (s.key.includes("attack-animation-")) data.system.settings.push(s);
+            if (s.key == "attack-animation-enable") {
+                enableSetting = s;
+            } else if (s.key.includes("attack-animation-")) {
+                settingPairs.push(s);
+            }
         }
+        data.system.settings.push(enableSetting);
+        data.system.settings.push({
+            type: "pairs",
+            pairs: settingPairs,
+        });
 
         // Return data
         return {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -59,9 +59,17 @@
     <section class="content" id="config-tabs">
         <div class="settings-list">
             <h2 class="module-header">{{ localize data.system.title }}</h2>
-            {{#each data.system.menus}} {{> menuPartial}} {{/each}} {{#each data.system.settings}} {{> settingPartialCustom}}
-            {{else}}
-            <p class="notes">{{localize 'SETTINGS.None'}}</p>
+            {{#each data.system.menus}} {{> menuPartial}} {{/each}}
+            {{#each data.system.settings}}
+                {{~#iff_custom this.type '==' 'pairs'~}}
+                    <div class="grid-2col">
+                        {{#each this.pairs}}
+                            {{> settingPartialCustom}}
+                        {{/each}}
+                    </div>
+                {{~else~}}
+                    {{> settingPartialCustom}}
+                {{~/iff_custom~}}
             {{/each}}
         </div>
     </section>


### PR DESCRIPTION
This change adds a "pairs" type to the settings template that renders the settings in a column.

For the record, I don't love the implementation. If you want me to change the names of anything, or restructure this code, let me know what you'd like changed.

Fixes #91