### PR TITLE
Prevent minion count from resetting after scene change

### DIFF
--- a/scripts/talent_checker.js
+++ b/scripts/talent_checker.js
@@ -66,14 +66,6 @@ export function talent_checker() {
                     let ranks = get_ranks(actor);
                     await update_status(token, ranks, game.settings.get("ffg-star-wars-enhancements", "talent-checker-status"));
                 }
-                if (game.settings.get("ffg-star-wars-enhancements", "minion-size-enable") && window.EffectCounter) {
-                    log(module_name, 'Found token ' + actor.name + '; searching for minion group size');
-                    let minion_count = get_group_size(actor);
-                    if (minion_count !== null) {
-                        log(module_name, 'Minion group ' + actor.data.name + ' is of size ' + minion_count);
-                        await update_status(token, minion_count, game.settings.get("ffg-star-wars-enhancements", "minion-size-status"));
-                    }
-                }
             }
         }
     });


### PR DESCRIPTION
Prevents status from resetting after scene change, so I don't need multiple actors to represent groups of different sizes. Just add a group with 4 minions, drag it on the scene, adjust the group size on the token and adjust the status effect to represent new group size. Without the change, after changing scenes, status effect is at 4 again, with the change  it keeps the adjusted value. Much better behaviour imo..