### PR TITLE
Fix ref for pull request tests

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # This directory caches the foundryvtt install avoiding abusive downloads.
       - name: Restore FoundryVTT CONTAINER_CACHE

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -85,8 +85,9 @@ jobs:
       - name: List contents of data dir for troubleshooting
         run: find data
 
-      # Capture the cypress test videos as an artifact
-      - name: Publish test videos
+      # Capture the cypress test videos as an artifact even upon failure
+      - if: ${{ always() }}
+        name: Publish test videos
         uses: actions/upload-artifact@v2
         with:
           name: cypress-test-videos

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ ffg-star-wars-enhancements.lock
 
 # ignore installed dependencies from npm
 node_modules
+
+# Ignore VSCode configuration
+.vscode/

--- a/cypress/.gitignore
+++ b/cypress/.gitignore
@@ -1,0 +1,2 @@
+screenshots/
+videos/


### PR DESCRIPTION
- Check out the pull request ref. Same security considerations apply as #133
- Adds an ignore for cypress output files (videos/screenshots) and vscode configuration
- Always store test videos, even on failure, since that's when they'll be the most useful

#131