### PR TITLE
Initialize the system, modules, and test world and run a test against the star wars crawl

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -63,6 +63,7 @@ jobs:
             --env FOUNDRY_LICENSE_KEY=${{ secrets.FOUNDRY_LICENSE_KEY }}
             --publish 30000:30000/tcp
             --volume ${{ github.workspace }}/data:/data
+            --volume ${{ github.workspace }}:/data/Data/modules/ffg-star-wars-enhancements
             felddy/foundryvtt:release
           wait-on: 'http://localhost:30000'
           wait-on-timeout: 120
@@ -78,6 +79,7 @@ jobs:
             --env FOUNDRY_LICENSE_KEY=${{ secrets.FOUNDRY_LICENSE_KEY }}
             --publish 30000:30000/tcp
             --volume ${{ github.workspace }}/data:/data
+            --volume ${{ github.workspace }}:/data/Data/modules/ffg-star-wars-enhancements
             felddy/foundryvtt:release
           wait-on: 'http://localhost:30000'
           wait-on-timeout: 120

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -53,8 +53,6 @@ jobs:
       - if: ${{ steps.container_cache.outputs.cache-hit != 'true' }}
         name: Launch FoundryVTT and run Cypress Tests
         uses: cypress-io/github-action@v5
-        env:
-          CYPRESS_BASE_URL: http://localhost:30000
         with:
           start: >-
             sudo docker run

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -40,7 +40,7 @@ jobs:
 
       # Ensure the directory exists for the volume mount
       - name: Initialized data directory
-        run: mkdir -p data
+        run: mkdir -p data/Data/modules/ffg-star-wars-enhancements
 
       # Executing the pull separately declutters the docker run command output.
       - name: Pull FoundryVTT Container
@@ -84,7 +84,8 @@ jobs:
           wait-on: 'http://localhost:30000'
           wait-on-timeout: 120
 
-      - name: List contents of data dir for troubleshooting
+      - if: ${{ always() }}
+        name: List contents of data dir for troubleshooting
         run: find data
 
       # Capture the cypress test videos as an artifact even upon failure

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -53,6 +53,8 @@ jobs:
       - if: ${{ steps.container_cache.outputs.cache-hit != 'true' }}
         name: Launch FoundryVTT and run Cypress Tests
         uses: cypress-io/github-action@v5
+        env:
+          FOUNDRY_URL: http://localhost:30000
         with:
           start: >-
             sudo docker run

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -40,7 +40,9 @@ jobs:
 
       # Ensure the directory exists for the volume mount
       - name: Initialized data directory
-        run: mkdir -p data/Data/modules/ffg-star-wars-enhancements
+        run: |
+          mkdir -p data/Data/modules/ffg-star-wars-enhancements
+          rsync -aP --exclude data --exclude .git * .??* data/Data/modules/ffg-star-wars-enhancements/
 
       # Executing the pull separately declutters the docker run command output.
       - name: Pull FoundryVTT Container
@@ -63,7 +65,6 @@ jobs:
             --env FOUNDRY_LICENSE_KEY=${{ secrets.FOUNDRY_LICENSE_KEY }}
             --publish 30000:30000/tcp
             --volume ${{ github.workspace }}/data:/data
-            --volume ${{ github.workspace }}:/data/Data/modules/ffg-star-wars-enhancements
             felddy/foundryvtt:release
           wait-on: 'http://localhost:30000'
           wait-on-timeout: 120
@@ -79,7 +80,6 @@ jobs:
             --env FOUNDRY_LICENSE_KEY=${{ secrets.FOUNDRY_LICENSE_KEY }}
             --publish 30000:30000/tcp
             --volume ${{ github.workspace }}/data:/data
-            --volume ${{ github.workspace }}:/data/Data/modules/ffg-star-wars-enhancements
             felddy/foundryvtt:release
           wait-on: 'http://localhost:30000'
           wait-on-timeout: 120

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -54,7 +54,7 @@ jobs:
         name: Launch FoundryVTT and run Cypress Tests
         uses: cypress-io/github-action@v5
         env:
-          FOUNDRY_URL: http://localhost:30000
+          CYPRESS_BASE_URL: http://localhost:30000
         with:
           start: >-
             sudo docker run

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 
 # Ignore VSCode configuration
 .vscode/
+
+# Ignore local cypress environment overrides for setting baseUrl
+cypress.env.json

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,16 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
+    /**
+     * Override baseUrl if provided via the config.env.json
+     * https://stackoverflow.com/questions/47262338/overriding-configuration-variables-from-cypress-env-json
+     */
+    setupNodeEvents(on, config) {
+      if (config.hasOwnProperty("env") && config.env.hasOwnProperty("baseUrl")) {
+        config.baseUrl = config.env.baseUrl;
+      }
+      return config;
+    },
     baseUrl: 'http://localhost:30000',
   },
   viewportWidth: 1920,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:30000',
+    baseUrl: 'http://example:30000', // Override with CYPRESS_BASE_URL
   },
   viewportWidth: 1920,
   viewportHeight: 1080,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -16,4 +16,6 @@ module.exports = defineConfig({
   },
   viewportWidth: 1920,
   viewportHeight: 1080,
+  defaultCommandTimeout: 15000,
+  videoCompression: 16
 });

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'http://example:30000', // Override with CYPRESS_BASE_URL
+    baseUrl: 'http://localhost:30000',
   },
   viewportWidth: 1920,
   viewportHeight: 1080,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -14,8 +14,7 @@ module.exports = defineConfig({
     },
     baseUrl: 'http://localhost:30000',
   },
-  viewportWidth: 1920,
-  viewportHeight: 1080,
-  defaultCommandTimeout: 60000,
-  videoCompression: 16
+  viewportWidth: 1440,
+  viewportHeight: 900,
+  defaultCommandTimeout: 60000
 });

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -16,6 +16,6 @@ module.exports = defineConfig({
   },
   viewportWidth: 1920,
   viewportHeight: 1080,
-  defaultCommandTimeout: 15000,
+  defaultCommandTimeout: 60000,
   videoCompression: 16
 });

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -31,10 +31,21 @@ describe.only("initialization", () => {
             cy.get('#notifications > .notification').contains('installed successfully', {timeout: 10000});
             // Close dialog
             cy.get('.header-button').click();
-
-            cy.get('.sheet-tabs > [data-tab="worlds"]').click();
           }
         });
+
+        // Navigate to install modules
+        cy.get('.sheet-tabs > [data-tab="modules"]').click();
+
+        // Cilck Install modules
+        cy.get('.active > .setup-footer > .install-package').click();
+
+        // Install fxmaster
+        cy.get('[data-package-id="fxmaster"] > .package-controls > .install').click();
+        cy.get('[data-package-id="lib-wrapper"] > .package-controls > .install').click();
+        cy.get('[data-package-id="statuscounter"] > .package-controls > .install').click();
+
+        cy.get('.sheet-tabs > [data-tab="worlds"]').click();
 
         // Open create world dialog
         cy.get('#create-world > label').click();
@@ -46,13 +57,12 @@ describe.only("initialization", () => {
         cy.get('form > :nth-child(3) > .form-fields > select').select('Star Wars FFG');
 
         // Create the world
-        cy.get('[type="submit"]').click();
+        cy.get('form > [type="submit"]').click();
 
         // Launch the world
         cy.get('.package-controls > [name="action"]').click();
       }
     });
-
 
     cy.visit(`${Cypress.config("baseUrl")}/join`);
     cy.url().should('eq', `${Cypress.config("baseUrl")}/join`);
@@ -64,5 +74,27 @@ describe.only("initialization", () => {
     cy.get(':nth-child(1) > button').click();
 
     cy.url().should('eq', `${Cypress.config("baseUrl")}/game`);
+
+    // Clear welcome message if it exists
+    cy.get('.step-header > .step-button > .far').click();
+
+    // Close warning
+    cy.get('.dialog-button').click();
+
+    // Close all notifications
+    //cy.get('#notifications .close').click({ multiple: true })
+
+    // Activate modules
+    cy.get('[data-tab="settings"] > .fas').click();
+
+    cy.get('[data-action="modules"]').click();
+
+    cy.get('.package-overview > .package-title > .active').click({multiple: true});
+
+    cy.get('footer.flexrow > [type="submit"]').click();
+
+    cy.get('.window-content > .dialog-buttons > .yes').click({multiple: true});
+
+    cy.get('[data-control="ffg-star-wars-enhancements"] > .fa').click();
   });
 });

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -108,7 +108,7 @@ function handlesSetup() {
 function closeNotifications() {
   cy.get('#notifications').then(($notifications) => {
     if ($notifications.children().length) {
-      cy.get("#notifications .close").first().click();
+      cy.get("#notifications .close").first().click({force: true});
 
       // Might introduce some brittleness, but I don't know a better way to work around this check right now.
       cy.wait(100);

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -29,7 +29,7 @@ function authenticatesAsAdmin() {
 /**
  * Installs module, but it assumes already on the add-on modules tab of setup.
  */
-function installModule($moduleList, module) {
+function installsModule($moduleList, module) {
   // Module already installed
   if ($moduleList.find(`[data-package-id="${module}"]`).length) {
     return;
@@ -73,9 +73,9 @@ function handlesSetup() {
 
       cy.get('.package-list').should('have.length.gt', 1)
 
-      installModule($moduleList, 'fxmaster');
-      installModule($moduleList, 'lib-wrapper');
-      installModule($moduleList, 'statuscounter');
+      installsModule($moduleList, 'fxmaster');
+      installsModule($moduleList, 'lib-wrapper');
+      installsModule($moduleList, 'statuscounter');
 
       // There's a quirk here where the close button isn't immediately ready to go. Double clicking just to hide it.
       cy.get('#install-package .header-button.close').dblclick();

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -238,7 +238,7 @@ describe.only("ffg-star-wars-enhancements", () => {
 
     // Open the crawl dialog
     cy.get('[data-control="ffg-star-wars-enhancements"]').click();
-    cy.get('[data-tool="opening-crawl"]').click({force: true});
+    cy.get('[data-tool="opening-crawl"]').click();
 
     // Create a folder for the Opening Crawl journals
     cy.get('.window-content .yes').click();

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -109,8 +109,9 @@ function handlesSetup() {
 function closeNotifications() {
   cy.get('#notifications').then(($notifications) => {
     if ($notifications.children().length) {
-      // Forced because notifications can scroll out of view
-      cy.get("#notifications .close").first().click({force: true});
+      // Clicking them in reverse order, because (I think) it avoids a problem
+      // with the notification jumping up after the click.
+      cy.get("#notifications .close").last().click();
 
       // Might introduce some brittleness, but I don't know a better way to work around this check right now.
       cy.wait(100);

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -199,7 +199,9 @@ function activateModules() {
  */
 function initializeWorld() {
   waitForWorld();
+  closeNotifications();
   closeInitialPopups();
+  closeNotifications();
 
   activateModules();
 }
@@ -218,6 +220,7 @@ describe.only("ffg-star-wars-enhancements", () => {
     waitForWorld();
     closeNotifications();
     closeInitialPopups();
+    closeNotifications();
 
     // Clean-up crawls if they exist
     cy.get('#sidebar-tabs > [data-tab="journal"]').click();

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -135,14 +135,19 @@ function closeInitialPopups() {
     $body.find('.app > .window-header > .window-title').each((_, titleEl) => {
       const title = Cypress.$(titleEl).text();
 
+      // Dismiss the warning related to not having all the plugins required
+      // enabled. This matters on initial world load.
       if (title === 'FFG Star Wars Enhancements') {
         cy.get('.app > .window-header > .window-title')
           .contains('FFG Star Wars Enhancements')
           .parent()
           .find('.header-button.close')
           .click({force: true}); // Forced because dialogs can overlap
+        // The above triggers a page reload due to it setting animations to off.
+        waitUntilReady();
       }
 
+      // Dismiss a warning about running head of the foundry codebase
       if (title === 'Warning') {
         cy.get('.app > .window-header > .window-title')
           .contains('Warning')
@@ -179,10 +184,17 @@ function waitUntilReady() {
 
   // Re-add if the FFG system doesn't seem initialized as this is close to the
   // last thing added during initialization
-  //cy.get('#destinyMenu');
+  cy.get('#destinyMenu');
 
   // Fixed delay: Brittle, but has been used prior to using game.ready
   //cy.wait(10000);
+
+  // The notifications can block the pop-ups and vice versa. So try the
+  // notifications first, then finish with notifications to clean up any
+  // missing.
+  closeNotifications();
+  closeInitialPopups();
+  closeNotifications();
 }
 
 function activateModules() {
@@ -212,9 +224,6 @@ function activateModules() {
  */
 function initializeWorld() {
   waitUntilReady();
-  closeNotifications();
-  closeInitialPopups();
-  closeNotifications();
 
   activateModules();
 }
@@ -231,9 +240,6 @@ describe.only("ffg-star-wars-enhancements", () => {
     cy.url().should('eq', `${Cypress.config("baseUrl")}/game`);
 
     waitUntilReady();
-    closeNotifications();
-    closeInitialPopups();
-    closeNotifications();
 
     // Clean-up crawls if they exist
     cy.get('#sidebar-tabs > [data-tab="journal"]').click();

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -234,8 +234,8 @@ describe.only("ffg-star-wars-enhancements", () => {
     });
 
     // Open the crawl dialog
-    cy.get('[data-control="ffg-star-wars-enhancements"]').click();
-    cy.get('[data-tool="opening-crawl"]').click();
+    cy.get('[data-control="ffg-star-wars-enhancements"]').click({force: true});
+    cy.get('[data-tool="opening-crawl"]').click({force: true});
 
     // Create a folder for the Opening Crawl journals
     cy.get('.window-content .yes').click();
@@ -246,8 +246,8 @@ describe.only("ffg-star-wars-enhancements", () => {
     // Can't seem to close the journal at this point, so just minimize it to keep it out of view
     cy.get('.journal-entry > .window-header > .close').dblclick();
 
-    cy.get('[data-control="ffg-star-wars-enhancements"]').click();
-    cy.get('[data-tool="opening-crawl"]').click();
+    cy.get('[data-control="ffg-star-wars-enhancements"]').click({force: true});
+    cy.get('[data-tool="opening-crawl"]').click({force: true});
 
     // Launch the opening crawl
     cy.get('#ffg-star-wars-enhancements-opening-crawl-select form button[type="submit"]').each(($button) => {

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -220,7 +220,52 @@ describe.only("ffg-star-wars-enhancements", () => {
     closeInitialPopups();
   });
 
-  it("loads", () => {
-    cy.get('body');
+  it.only("creates and launches an opening crawl", () => {
+    // Clean-up crawls if they exist
+    cy.get('#sidebar-tabs > [data-tab="journal"]').click();
+    cy.get('#journal > .directory-list').then(($directoryList) => {
+      if ($directoryList.find('.folder').length == 0) {
+        return;
+      }
+      cy.get('#journal > .directory-list header h3').contains('Opening Crawls').rightclick();
+
+      cy.get('#context-menu > .context-items > .context-item').contains('Delete All').click();
+
+      // Confirm
+      cy.get('.window-content > .dialog-buttons > .yes').click();
+    });
+
+    // Open the crawl dialog
+    cy.get('[data-control="ffg-star-wars-enhancements"]').click();
+    cy.get('[data-tool="opening-crawl"]').click();
+
+    // Create a folder for the Opening Crawl journals
+    cy.get('.window-content .yes').click();
+
+    // Create a crawl
+    cy.get('#ffg-star-wars-enhancements-opening-crawl-select .create').click();
+
+    // Can't seem to close the journal at this point, so just minimize it to keep it out of view
+    cy.get('.journal-entry > .window-header > .close').dblclick();
+
+    cy.get('[data-control="ffg-star-wars-enhancements"]').click();
+    cy.get('[data-tool="opening-crawl"]').click();
+
+    // Launch the opening crawl
+    cy.get('#ffg-star-wars-enhancements-opening-crawl-select form button[type="submit"]').each(($button) => {
+      if ($button.text() == 'Launch') {
+        $button.click();
+      }
+    });
+
+    cy.get('#ffg-star-wars-enhancements-opening-crawl').should('be.visible');
+
+    // Verify the image at the bottom of the crawl exists
+    cy.get('#ffg-star-wars-enhancements-opening-crawl .backgroundSpace img').should('exist');
+
+    // Purely to capture some of the crawl on video
+    cy.wait(10000);
+
+    cy.get('#ffg-star-wars-enhancements-opening-crawl .header-button.close').click();
   });
 });

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -1,8 +1,68 @@
-describe.only("empty spec", () => {
-   it.only("passes", () => {
-     cy.visit("/");
-     cy.url().should('be.equal', `${Cypress.config("baseUrl")}/license`);
-     // Temporary wait statement to make sure license page actually loads
-     cy.wait(1000);
-   });
- });
+describe.only("initialization", () => {
+  it.only("completes", () => {
+    cy.visit("/");
+
+    // Accept the license agreement
+    cy.url().then((url) => {
+      if (url == `${Cypress.config("baseUrl")}/license`) {
+        cy.get("#eula-agree").check();
+        cy.get("#sign").click();
+      }
+    })
+
+    // Enter the Admin key if not already logged in
+    cy.url().then((url) => {
+      if (url == `${Cypress.config("baseUrl")}/auth`) {
+        cy.get('#key').type("test-admin-key{enter}");
+      }
+    })
+
+    cy.url().then((url) => {
+      if (url == `${Cypress.config("baseUrl")}/setup`) {
+        // Install FFG System
+        cy.get('.sheet-tabs > .active').then((el) => {
+          if (el[0].dataset.tab == 'systems') {
+            // Click Install System
+            cy.get('.active > .setup-footer > .install-package').click();
+
+            // Click Install for Star Wars FFG system
+            cy.get('[data-package-id="starwarsffg"] > .package-controls > .install').click();
+
+            cy.get('#notifications > .notification').contains('installed successfully', {timeout: 10000});
+            // Close dialog
+            cy.get('.header-button').click();
+
+            cy.get('.sheet-tabs > [data-tab="worlds"]').click();
+          }
+        });
+
+        // Open create world dialog
+        cy.get('#create-world > label').click();
+
+        // Name the system
+        cy.get(':nth-child(1) > .form-fields > input').type('Integration Test World', {force: true});
+
+        // Select the system
+        cy.get('form > :nth-child(3) > .form-fields > select').select('Star Wars FFG');
+
+        // Create the world
+        cy.get('[type="submit"]').click();
+
+        // Launch the world
+        cy.get('.package-controls > [name="action"]').click();
+      }
+    });
+
+
+    cy.visit(`${Cypress.config("baseUrl")}/join`);
+    cy.url().should('eq', `${Cypress.config("baseUrl")}/join`);
+
+    // Select game master
+    cy.get('select').select("Gamemaster");
+
+    // Join Game Session
+    cy.get(':nth-child(1) > button').click();
+
+    cy.url().should('eq', `${Cypress.config("baseUrl")}/game`);
+  });
+});

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -221,6 +221,10 @@ describe.only("ffg-star-wars-enhancements", () => {
   });
 
   it.only("creates and launches an opening crawl", () => {
+    waitForWorld();
+    closeNotifications();
+    closeInitialPopups();
+
     // Clean-up crawls if they exist
     cy.get('#sidebar-tabs > [data-tab="journal"]').click();
     cy.get('#journal > .directory-list').then(($directoryList) => {

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -189,10 +189,6 @@ function waitUntilReady() {
   // Fixed delay: Brittle, but has been used prior to using game.ready
   //cy.wait(10000);
 
-  // The notifications can block the pop-ups and vice versa. So try the
-  // notifications first, then finish with notifications to clean up any
-  // missing.
-  closeNotifications();
   closeInitialPopups();
   closeNotifications();
 }

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -213,6 +213,7 @@ describe.only("ffg-star-wars-enhancements", () => {
 
   beforeEach(() => {
     cy.visit("/game");
+    cy.url().should('eq', `${Cypress.config("baseUrl")}/game`);
 
     waitForWorld();
     closeNotifications();

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -237,7 +237,7 @@ describe.only("ffg-star-wars-enhancements", () => {
     });
 
     // Open the crawl dialog
-    cy.get('[data-control="ffg-star-wars-enhancements"]').click({force: true});
+    cy.get('[data-control="ffg-star-wars-enhancements"]').click();
     cy.get('[data-tool="opening-crawl"]').click({force: true});
 
     // Create a folder for the Opening Crawl journals
@@ -249,8 +249,8 @@ describe.only("ffg-star-wars-enhancements", () => {
     // Can't seem to close the journal at this point, so just minimize it to keep it out of view
     cy.get('.journal-entry > .window-header > .close').dblclick();
 
-    cy.get('[data-control="ffg-star-wars-enhancements"]').click({force: true});
-    cy.get('[data-tool="opening-crawl"]').click({force: true});
+    cy.get('[data-control="ffg-star-wars-enhancements"]').click();
+    cy.get('[data-tool="opening-crawl"]').click();
 
     // Launch the opening crawl
     cy.get('#ffg-star-wars-enhancements-opening-crawl-select form button[type="submit"]').each(($button) => {

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -211,16 +211,10 @@ describe.only("ffg-star-wars-enhancements", () => {
     initializeWorld();
   });
 
-  beforeEach(() => {
+  it.only("creates and launches an opening crawl", () => {
     cy.visit("/game");
     cy.url().should('eq', `${Cypress.config("baseUrl")}/game`);
 
-    waitForWorld();
-    closeNotifications();
-    closeInitialPopups();
-  });
-
-  it.only("creates and launches an opening crawl", () => {
     waitForWorld();
     closeNotifications();
     closeInitialPopups();

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -169,7 +169,7 @@ function join(user = "Gamemaster") {
 function waitForWorld() {
   // TODO: Find a better hooks - this will likely be brittle
   cy.get('#destinyMenu');
-  cy.wait(1000);
+  cy.wait(10000);
 }
 
 function activateModules() {


### PR DESCRIPTION
- Copy code base into the foundry modules directory to "install" the module
- Adds helper functions to initialize the FFG system, required modules, and an integration test world
- Adds an integration test for running a opening crawl
- Optionally source cypress baseUrl from cypress.env.json 

Note:
These tests have to be very resilient to race conditions, because the github-ci environment is very overloaded. Avoid waits and force clicks. Force will click the element before it's "ready" per cypress. Sometimes this makes sense, like if one dialog might be covering another, but I think in this case it's a bandaid that's actually triggering more downstream issues. I think the element becomes ready before it's actually clickable.