### PR TITLE
fix(animation): Decrease lower bound on animations when count provided

### DIFF
--- a/scripts/animation.js
+++ b/scripts/animation.js
@@ -380,7 +380,7 @@ async function play_animation(animation_file, sound_file, skill, source, count) 
             var lower_bound = 1;
             var num_shots = 1;
         } else {
-            var lower_bound = 2;
+            var lower_bound = 1;
             // noinspection JSDuplicatedDeclaration
             var num_shots = Math.floor((Math.random() * 6) + 1);
         }


### PR DESCRIPTION
The lower and upper bounds are deltas, so setting the default to 2 causes animations with 1 set to not work.

Closes: #129 