### PR TITLE
fix(tests): Fix race condition with closing initial popups in cypress tests

### DIFF
--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -141,9 +141,14 @@ function closeInitialPopups() {
         cy.get('.app > .window-header > .window-title')
           .contains('FFG Star Wars Enhancements')
           .parent()
-          .find('.header-button.close')
-          .click({force: true}); // Forced because dialogs can overlap
+          .parent()
+          .find('.dialog-button')
+          .click({force: true}) // Forced because dialogs can overlap
+          .should('not.exist');
+
         // The above triggers a page reload due to it setting animations to off.
+        cy.visit("/game");
+        cy.url().should('eq', `${Cypress.config("baseUrl")}/game`);
         waitUntilReady();
       }
 
@@ -152,7 +157,8 @@ function closeInitialPopups() {
         cy.get('.app > .window-header > .window-title')
           .contains('Warning')
           .parent()
-          .find('.header-button.close')
+          .parent()
+          .find('.dialog-button')
           .click({force: true}); // Forced because dialogs can overlap
       }
     });


### PR DESCRIPTION
It turns out that FoundryVTT has a 500ms delay before their close buttons become active to prevent accidental closures. Unfortunately, I haven't yet found a way to wait for the event handler to be attached.

This change switches to clicking the accept buttons, which don't have that delay.

This bug likely impacts other close buttons. (I have a double click to work around this in an earlier step in initialization, but that's not a blocker currently.)