### PR TITLE
fix(cypress): correct dialog closing issue

### DIFF
--- a/cypress/e2e/02_opening_crawl.cy.js
+++ b/cypress/e2e/02_opening_crawl.cy.js
@@ -16,7 +16,7 @@ describe("ffg-star-wars-enhancements opening crawl", () => {
             cy.get("#context-menu > .context-items > .context-item").contains("Delete All").click();
 
             // Confirm
-            cy.get(".window-content > .dialog-buttons > .yes").click();
+            cy.get(".window-content > .dialog-buttons > .yes").click().should("not.exist");
         });
 
         // Open the crawl dialog


### PR DESCRIPTION
* now waits for the dialog to close instead of assuming it closed (this was an issue with Foundry running on a remote host)