### PR TITLE
tests(dice_helper): first pass at dice helper end-to-end test

### DIFF
--- a/cypress/e2e/03_dice_helper.cy.js
+++ b/cypress/e2e/03_dice_helper.cy.js
@@ -1,0 +1,88 @@
+/***
+ * Clears the entire chat history
+ */
+function clear_chat() {
+    cy.get(".fa-comments").click();
+    cy.get(".delete > .fas").click();
+    cy.get(".yes").click();
+}
+
+/***
+ * Rolls the specified skill within an open actor sheet
+ * @param skill_name
+ */
+function roll_skill(skill_name) {
+    cy.get('.sheet-tabs > [data-tab="items"]').click();
+    cy.get(":nth-child(2) > .items-header > .header-name").should("be.visible");
+    cy.get('.sheet-tabs > [data-tab="characteristics"]').click();
+    // not sure why force is needed, but using just .click results in the characteristics in the sheet disappearing
+    cy.get(`[data-ability="${skill_name}"] .roll-button > :nth-child(1)`).click({ force: true });
+    cy.get(":nth-child(5) > summary").click(); // expand the fixed results tab
+    cy.get(".pool-additional-container > tbody > :nth-child(2) > :nth-child(2) > input")
+        .click()
+        .click()
+        .click()
+        .click()
+        .click(); // click 5 times to add 5 advantage, so we always have at least 1
+    // roll the dice
+    cy.get(".btn").click();
+}
+
+describe("ffg-star-wars-enhancements dice helper", () => {
+    beforeEach(() => {
+        cy.join();
+        cy.waitUntilReady();
+    });
+
+    it("creates and stats an actor, then generates and clicks dice helper button", () => {
+        clear_chat();
+        /*
+            Delete old actors (if any)
+         */
+        cy.get('[data-tab="actors"] > .fas').click();
+        cy.get("#actors > .directory-list").then(($actorList) => {
+            if ($actorList.length === 0) {
+                return;
+            }
+            // Confirm
+            cy.get(".actor > .document-name > a").rightclick();
+            cy.get(".context-items > :nth-child(1)").click();
+            cy.get(".yes").click();
+        });
+        /*
+            Create an actor and give it stats, so we can roll
+         */
+        cy.get("#actors > .directory-header > .header-actions > .create-document").click();
+        cy.get(".form-fields > input").type("dice roller test actor", { force: true });
+        cy.get(".dialog-button").click();
+        cy.get(".window-app.actor").should("exist").and("be.visible");
+
+        cy.get('.sheet-tabs > [data-tab="items"]').click();
+        cy.get(":nth-child(2) > .items-header > .header-name").should("be.visible");
+        cy.get('.sheet-tabs > [data-tab="characteristics"]').click();
+
+        cy.get('[data-ability="Brawn"] > .characteristic > .characteristic-value > input').type("{backspace}2");
+        cy.get('[data-ability="Brawn"] > .characteristic > .characteristic-value > input').blur();
+
+        cy.get('.sheet-tabs > [data-tab="items"]').click();
+        cy.get(":nth-child(2) > .items-header > .header-name").should("be.visible");
+        cy.get('.sheet-tabs > [data-tab="characteristics"]').click();
+
+        cy.get('[data-ability="Agility"] > .characteristic > .characteristic-value > input').type("{backspace}2");
+        cy.get('[data-ability="Agility"] > .characteristic > .characteristic-value > input').blur();
+
+        /*
+            Actually perform the rolls and click the resulting button
+        */
+        roll_skill("Brawl");
+        cy.get(".fa-comments").click(); // navigate to the chat tab
+        cy.get(".effg-die-result").should("be.visible").click();
+        cy.get(".dice_helper").contains("for spending result");
+
+        clear_chat();
+        roll_skill("Ranged: Light");
+        cy.get(".fa-comments").click();
+        cy.get(".effg-die-result").should("be.visible").click();
+        cy.get(".dice_helper").contains("for spending result");
+    });
+});

--- a/cypress/e2e/03_dice_helper.cy.js
+++ b/cypress/e2e/03_dice_helper.cy.js
@@ -41,7 +41,7 @@ describe("ffg-star-wars-enhancements dice helper", () => {
          */
         cy.get('[data-tab="actors"] > .fas').click();
         cy.get("#actors > .directory-list").then(($actorList) => {
-            if ($actorList.length === 0) {
+            if ($actorList[0].children.length === 0) {
                 return;
             }
             // Confirm

--- a/cypress/e2e/03_dice_helper.cy.js
+++ b/cypress/e2e/03_dice_helper.cy.js
@@ -65,5 +65,6 @@ describe("ffg-star-wars-enhancements dice helper", () => {
         cy.get(".fa-comments").click();
         cy.get(".effg-die-result").should("be.visible").click();
         cy.get(".dice_helper").contains("for spending result");
+        cleanup_actors();
     });
 });

--- a/cypress/e2e/03_dice_helper.cy.js
+++ b/cypress/e2e/03_dice_helper.cy.js
@@ -1,11 +1,4 @@
-/***
- * Clears the entire chat history
- */
-function clear_chat() {
-    cy.get(".fa-comments").click();
-    cy.get(".delete > .fas").click();
-    cy.get(".yes").click();
-}
+import { clear_chat, cleanup_actors } from "../support/common.js";
 
 /***
  * Rolls the specified skill within an open actor sheet
@@ -36,19 +29,7 @@ describe("ffg-star-wars-enhancements dice helper", () => {
 
     it("creates and stats an actor, then generates and clicks dice helper button", () => {
         clear_chat();
-        /*
-            Delete old actors (if any)
-         */
-        cy.get('[data-tab="actors"] > .fas').click();
-        cy.get("#actors > .directory-list").then(($actorList) => {
-            if ($actorList[0].children.length === 0) {
-                return;
-            }
-            // Confirm
-            cy.get(".actor > .document-name > a").rightclick();
-            cy.get(".context-items > :nth-child(1)").click();
-            cy.get(".yes").click();
-        });
+        cleanup_actors();
         /*
             Create an actor and give it stats, so we can roll
          */

--- a/cypress/support/common.js
+++ b/cypress/support/common.js
@@ -1,0 +1,21 @@
+export function cleanup_actors() {
+    cy.get('[data-tab="actors"] > .fas').click();
+    cy.get("#actors > .directory-list").then(($actorList) => {
+        if ($actorList[0].children.length === 0) {
+            return;
+        }
+        // Confirm
+        cy.get(".actor > .document-name > a").rightclick();
+        cy.get(".context-items > :nth-child(1)").click();
+        cy.get(".yes").click();
+    });
+}
+
+/**
+ * Clears the entire chat history
+ */
+export function clear_chat() {
+    cy.get(".fa-comments").click();
+    cy.get(".delete > .fas").click();
+    cy.get(".yes").click();
+}

--- a/templates/dice_helper.html
+++ b/templates/dice_helper.html
@@ -1,3 +1,4 @@
+<span class="dice_helper">
 {{localize "ffg-star-wars-enhancements.dice-helper-message-content-1"}} <b>{{localize "ffg-star-wars-enhancements.dice-helper-message-content-2"}}</b> {{localize "ffg-star-wars-enhancements.dice-helper-message-content-3"}} <b>{{this.skill}}</b>:<br>
 
 {{#each this.suggestions}}
@@ -7,3 +8,4 @@
         {{this.text}}<br>
     {{/each}}
 {{/each}}
+</span>


### PR DESCRIPTION
Adds tests for the dice helper on both a Brawl and Ranged - Light attack. These two skills were chosen because we've sometime seen issues in generating helper results when there's a space in the skill name, so the mix of the two should help capture complete results.

As a dependency of this, the tests clear chat logs and create a test actor.