### PR TITLE
fix(settings): standardise popup settings window titles

### DIFF
--- a/scripts/animation.js
+++ b/scripts/animation.js
@@ -452,7 +452,7 @@ class attack_animation_UISettings extends FormApplication {
         return mergeObject(super.defaultOptions, {
             id: "data-importer",
             classes: ["starwarsffg", "data-import"],
-            title: `${game.i18n.localize("SWFFG.UISettingsLabel")}`,
+            title: `${game.i18n.localize("ffg-star-wars-enhancements.attack-animation.ui.name")}`,
             template: "modules/ffg-star-wars-enhancements/templates/settings.html",
         });
     }

--- a/scripts/opening_crawl.js
+++ b/scripts/opening_crawl.js
@@ -375,7 +375,7 @@ class opening_crawl_UISettings extends FormApplication {
         return mergeObject(super.defaultOptions, {
             id: "data-importer",
             classes: ["starwarsffg", "data-import"],
-            title: `${game.i18n.localize("SWFFG.UISettingsLabel")}`,
+            title: `${game.i18n.localize("ffg-star-wars-enhancements.opening-crawl.ui.name")}`,
             template: "modules/ffg-star-wars-enhancements/templates/settings.html",
         });
     }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -58,7 +58,6 @@
 <form autocomplete="off" class="flexcol">
     <section class="content" id="config-tabs">
         <div class="settings-list">
-            <h2 class="module-header">{{ localize data.system.title }}</h2>
             {{#each data.system.menus}} {{> menuPartial}} {{/each}} {{#each data.system.settings}} {{> settingPartialCustom}}
             {{else}}
             <p class="notes">{{localize 'SETTINGS.None'}}</p>


### PR DESCRIPTION
Updates the settings.html theme file to remove the redundant header, and sets the opening crawl and attack animation settings popups to use the correct title rather than the generic "UI Settings Manager" title.

![image](https://github.com/wrycu/StarWarsFFG-Enhancements/assets/22210423/48d967bc-bf79-4ba6-a25f-c633adbf56b0)

100% necessary fixes update module immediate