### PR TITLE
fix(datapad): correct bounty CSS

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,7 @@
 `2.1.0` - ?
 
 -   COMPATABILITY: Module updated to work with FoundryVTT v12
+-   FIX: Correct Bounty CSS datapad breaking after editing
 
 `2.0.6` - 2024-04-06
 

--- a/styles/datapads.css
+++ b/styles/datapads.css
@@ -120,6 +120,12 @@
     font-size: 16px;
 }
 
+.swdatapad-wanted table p {
+    font-size: 14px;
+    margin-bottom: initial;
+    margin-top: initial;
+}
+
 .swdatapad-wanted p {
     font-size: 14px;
     margin-bottom: 1em;


### PR DESCRIPTION
* fixes paragraph CSS within the bounty datapad, since Foundry adds paragraphs to table elements (which I assume is new since this was written)

#183