### PR TITLE
Fix usage of Attack Animation (Item)

### DIFF
--- a/scripts/animation.js
+++ b/scripts/animation.js
@@ -332,7 +332,7 @@ export function attack_animation(...args) {
                 "attack-animation-custom-entries"
             );
             const matching_custom_setting = custom_item_animations.find((i) =>
-                (i && i.name != "" && item_name?.toLowerCase()?.includes(i.name.toLowerCase()))
+                (i && i.name != "" && item_name?.toLowerCase()?.includes(i.name?.toLowerCase()))
             );
             if (item_name && matching_custom_setting) {
                 log(


### PR DESCRIPTION
The first entry of the list 'custom_item_animations' is not valid because it's the 'new entry' without information. But it's always match with the item_name so the choosen animation is an empty one. the two names are not lower case so the match is not exact. i fix the log that use the list instead of the value found.

Thanks for your work it's awsome.